### PR TITLE
FOLIO-SRU ergänzt

### DIFF
--- a/signaturenDruck/js/classes/DataFromSRU.js
+++ b/signaturenDruck/js/classes/DataFromSRU.js
@@ -1,5 +1,4 @@
 const { net } = require('electron')
-const { XMLParser } = require("fast-xml-parser")
 
 const Store = require('electron-store')
 const C = require('./Config')
@@ -41,14 +40,6 @@ class DataFromSRU {
       }
       const url = config.get('SRU.SRUAddress') + queryPart1 + key + config.get('SRU.QueryPart2')
       const request = net.request(url)
-      const options = {
-        ignoreAttributes: false,
-        attributeNamePrefix : "",
-        numberParseOptions: {
-          leadingZeros: false
-        }
-      }
-      const parser = new XMLParser(options)
       let allData = ''
       let data = ''
       return new Promise(function (resolve, reject) {
@@ -61,7 +52,7 @@ class DataFromSRU {
             reject(error)
           })
           response.on('end', () => {
-            resolve(parser.parse(allData))
+            resolve(allData)
           })
         })
         request.end()

--- a/signaturenDruck/js/classes/ShelfmarksFromSRUData.js
+++ b/signaturenDruck/js/classes/ShelfmarksFromSRUData.js
@@ -1,4 +1,6 @@
 const _ = require('lodash')
+const xpath = require('xpath')
+const dom = require('@xmldom/xmldom').DOMParser
 const Shelfmark = require('../shelfmark.js')
 const Modes = require('./Modes.js')
 const Store = require('electron-store')
@@ -36,21 +38,48 @@ class ShelfmarksFromSRUData {
     const mode = new Modes()
     const formats = new Formats()
     const formatArray = formats.formats
-    sig.error = getError(xml, key, dataMode)
+    
+    const srudom = new dom()
+    
+    try {
+        var sru = srudom.parseFromString(xml, 'text/xml')
+        var selectzs = xpath.useNamespaces({"zs": "http://www.loc.gov/zing/srw/"})
+        if (selectzs("number(/zs:searchRetrieveResponse/zs:numberOfRecords)", sru) === 1) {
+            sig.error = ''
+        } else {
+            sig.error = key + ' wurde nicht gefunden. (Modus ' + dataMode + ')' // more than one hit should never happen
+        }
+     } catch (e) {
+        sig.error = e.message
+     }
 
     if (sig.error === '') {
-      const occ = getOccurrence(xml, key)
+
       sig.id = 99 // gets overwritten at a later stage
-      if (dataMode === 'PPN') {
-        sig.ppn = getPPN(xml)
-      } else {
-        sig.ppn = getEPN(xml)
+
+      switch (selectzs("string(//zs:record/zs:recordSchema)", sru)) {
+       case 'picaxml':
+       case 'info:srw/schema/5/picaXML-v1.0':
+          var selectpica = xpath.useNamespaces({"zs": "http://www.loc.gov/zing/srw/", "pica": "info:srw/schema/5/picaXML-v1.0"})
+          if (dataMode === 'PPN') {
+            sig.ppn = selectpica("string(//pica:datafield[@tag='003@']/pica:subfield[@code='0'])", sru)
+            var occ = selectpica("string(//pica:datafield[(@tag='209G') and (pica:subfield[@code='a']='"+key+"')]/@occurrence)", sru)
+          } else {
+            sig.ppn = key
+            var occ = selectpica("string(//pica:datafield[(@tag='203@') and (pica:subfield[@code='0']='"+key+"')]/@occurrence)", sru)
+          }
+          sig.date = selectpica("string(//pica:datafield[(@tag='201B') and (@occurrence='"+occ+"')]/pica:subfield[@code='0'])", sru)
+          sig.txtOneLine = selectpica("string(//pica:datafield[(@tag='209A') and (@occurrence='"+occ+"')]/pica:subfield[@code='a'])", sru)
+          sig.exNr = occ
+          sig.location = selectpica("string(//pica:datafield[(@tag='200A') and (@occurrence='"+occ+"')]/pica:subfield[@code='f'])", sru)
+          sig.loanIndication = selectpica("string(//pica:datafield[(@tag='200A') and (@occurrence='"+occ+"')]/pica:subfield[@code='d'])", sru)
+          break
+          
+        default:
+          sig.error = 'SRU: Unbekanntes Datenschema'
+          
       }
-      sig.date = getDate(xml, occ)
-      sig.txtOneLine = getTxt(xml, occ)
-      sig.exNr = getExNr(xml, occ)
-      sig.location = getLocation(xml, occ)
-      sig.loanIndication = getLoanIndication(xml, occ)
+      
       const allSubModeData = mode.modes[config.get('mode.defaultMode')].subModes
       _.forEach(allSubModeData, function (value) {
         const data = {
@@ -89,115 +118,6 @@ class ShelfmarksFromSRUData {
     }
 
     return sig.shelfmark
-  }
-}
-
-function getOccurrence (object, barcode) {
-  // get all 209G entries
-  const all = _.filter(object['zs:searchRetrieveResponse']['zs:records']['zs:record']['zs:recordData'].record.datafield, { tag: '209G' })
-  // search all 209G for a matching barcode
-  let found = _.find(all, function (o) {
-    // if there are multiple subfield entries
-    if (o.subfield.length > 1) {
-      // return the subield entry with the matching barcode
-      return _.forEach(o.subfield, function (data) {
-        if (data['#text'] === barcode) {
-          return o
-        }
-      })
-    } else { // if there is just one subfield entry
-      if (o.subfield['#text'] === barcode) {
-        return o
-      }
-    }
-  })
-  // if the barcode did not match, we take the occurrence of the first 209A entry
-  if (found === undefined) {
-    const test = _.find(object['zs:searchRetrieveResponse']['zs:records']['zs:record']['zs:recordData'].record.datafield, { tag: '209A' })
-    // if we found something
-    if (test !== undefined) {
-      found = test
-    }
-  }
-  return found.occurrence
-}
-
-function getPPN (object) {
-  const data = _.find(object['zs:searchRetrieveResponse']['zs:records']['zs:record']['zs:recordData'].record.datafield, { tag: '003@' })
-  if (data !== undefined) {
-    return String(data.subfield['#text'])
-  } else {
-    return ''
-  }
-}
-
-function getEPN (object) {
-  const data = _.find(object['zs:searchRetrieveResponse']['zs:records']['zs:record']['zs:recordData'].record.datafield, { tag: '203@' })
-  if (data !== undefined) {
-    return String(data.subfield['#text'])
-  } else {
-    return ''
-  }
-}
-
-function getDate (object, occ) {
-  const parent = _.find(object['zs:searchRetrieveResponse']['zs:records']['zs:record']['zs:recordData'].record.datafield, { tag: '201B', occurrence: occ })
-  const data = _.find(parent.subfield, { code: '0' })
-  if (data !== undefined) {
-    return data['#text']
-  } else {
-    return ''
-  }
-}
-
-function getTxt (object, occ) {
-  const parent = _.find(object['zs:searchRetrieveResponse']['zs:records']['zs:record']['zs:recordData'].record.datafield, { tag: '209A', occurrence: occ })
-  const data = _.find(parent.subfield, { code: 'a' })
-  if (data !== undefined) {
-    return data['#text']
-  } else {
-    return ''
-  }
-}
-
-function getExNr (object, occ) {
-  const data = _.find(object['zs:searchRetrieveResponse']['zs:records']['zs:record']['zs:recordData'].record.datafield, { tag: '209A', occurrence: occ })
-  if (data !== undefined) {
-    return data.occurrence
-  } else {
-    return ''
-  }
-}
-
-function getLocation (object, occ) {
-  const parent = _.find(object['zs:searchRetrieveResponse']['zs:records']['zs:record']['zs:recordData'].record.datafield, { tag: '209A', occurrence: occ })
-  const data = _.find(parent.subfield, { code: 'f' })
-  if (data !== undefined) {
-    return data['#text']
-  } else {
-    return ''
-  }
-}
-
-function getLoanIndication (object, occ) {
-  const parent = _.find(object['zs:searchRetrieveResponse']['zs:records']['zs:record']['zs:recordData'].record.datafield, { tag: '209A', occurrence: occ })
-  const data = _.find(parent.subfield, { code: 'd' })
-  if (data !== undefined) {
-    return data['#text']
-  } else {
-    return ''
-  }
-}
-
-function getError (object, key, mode) {
-  try {
-    if (object && object['zs:searchRetrieveResponse'] && object['zs:searchRetrieveResponse']['zs:numberOfRecords'] > 0) {
-      return ''
-    } else {
-      return mode + ': <b>' + key + '</b> wurde nicht gefunden.'
-    }
-  } catch (e) {
-    return e.message
   }
 }
 

--- a/signaturenDruck/js/classes/ShelfmarksFromSRUData.js
+++ b/signaturenDruck/js/classes/ShelfmarksFromSRUData.js
@@ -74,8 +74,25 @@ class ShelfmarksFromSRUData {
           sig.location = selectpica("string(//pica:datafield[(@tag='200A') and (@occurrence='"+occ+"')]/pica:subfield[@code='f'])", sru)
           sig.loanIndication = selectpica("string(//pica:datafield[(@tag='200A') and (@occurrence='"+occ+"')]/pica:subfield[@code='d'])", sru)
           break
-          
-        default:
+ 
+       case 'raw':  // FOLIO "Quesnelia"
+          if (dataMode === 'PPN') {
+            sig.ppn = xpath.select("string(//bareHoldingsItems[barcode='"+key+"']/hrid)", sru)
+            sig.date = xpath.select("string(//bareHoldingsItems[barcode='"+key+"']/../notes[holdingsNoteType/name='Letzte Änderung CBS']/note)", sru)
+            sig.txtOneLine = [
+                   xpath.select("string(//bareHoldingsItems[barcode='"+key+"']/effectiveCallNumberComponents/prefix)", sru),
+                   xpath.select("string(//bareHoldingsItems[barcode='"+key+"']/effectiveCallNumberComponents/callNumber)", sru),
+                   xpath.select("string(//bareHoldingsItems[barcode='"+key+"']/effectiveCallNumberComponents/suffix)", sru)
+                   ].join(" ")
+            sig.location = xpath.select("string(//bareHoldingsItems[barcode='"+key+"']/../permanentLocation/name)", sru)
+            sig.exNr = sig.location
+            sig.loanIndication = xpath.select("string(//bareHoldingsItems[barcode='"+key+"']/status/name)", sru)
+          } else {
+            sig.error = 'SRU: EPN-Suche für FOLIO raw nicht implementiert'
+          }
+          break
+
+       default:
           sig.error = 'SRU: Unbekanntes Datenschema'
           
       }

--- a/signaturenDruck/package-lock.json
+++ b/signaturenDruck/package-lock.json
@@ -1,18 +1,18 @@
 {
   "name": "SignaturenDruck",
-  "version": "1.3.19",
+  "version": "1.3.20",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "SignaturenDruck",
-      "version": "1.3.19",
+      "version": "1.3.20",
       "license": "CC0 1.0",
       "dependencies": {
+        "@xmldom/xmldom": "^0.9.6",
         "electron-context-menu": "^3.1.1",
         "electron-squirrel-startup": "^1.0.0",
         "electron-store": "^8.0.1",
-        "fast-xml-parser": "^4.3.5",
         "lodash": "^4.17.21",
         "moment": "^2.29.1",
         "pdf-to-printer": "^5.0.0",
@@ -20,7 +20,7 @@
         "sweetalert2": "^11.1.9",
         "system-font-families": "^0.4.1",
         "username": "^5.1.0",
-        "xml2json": "^0.12.0",
+        "xpath": "^0.0.34",
         "xregexp": "^5.1.0"
       },
       "devDependencies": {
@@ -594,6 +594,43 @@
         "node": ">=10"
       }
     },
+    "node_modules/@electron/windows-sign": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@electron/windows-sign/-/windows-sign-1.2.0.tgz",
+      "integrity": "sha512-5zfLHfD6kGgsXzuYlKwlWWO8w6dboKy4dhd7rGnR4rQYumuDgPAF2TYjEa8LUi89KdHxtDy2btq02KvbjhK9Iw==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "optional": true,
+      "dependencies": {
+        "cross-dirname": "^0.1.0",
+        "debug": "^4.3.4",
+        "fs-extra": "^11.1.1",
+        "minimist": "^1.2.8",
+        "postject": "^1.0.0-alpha.6"
+      },
+      "bin": {
+        "electron-windows-sign": "bin/electron-windows-sign.js"
+      },
+      "engines": {
+        "node": ">=14.14"
+      }
+    },
+    "node_modules/@electron/windows-sign/node_modules/fs-extra": {
+      "version": "11.3.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.3.0.tgz",
+      "integrity": "sha512-Z4XaCL6dUDHfP/jT25jJKMmtxvuwbkrD1vNSMFlo9lNLY2c5FHYSQgHPRZUjAB26TpDEoW9HCOgplrdbaPV/ew==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^6.0.1",
+        "universalify": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=14.14"
+      }
+    },
     "node_modules/@isaacs/cliui": {
       "version": "8.0.2",
       "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz",
@@ -883,12 +920,12 @@
       }
     },
     "node_modules/@xmldom/xmldom": {
-      "version": "0.8.10",
-      "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.8.10.tgz",
-      "integrity": "sha512-2WALfTl4xo2SkGCYRt6rDTFfk9R1czmBvUQy12gK2KuRKIpWEhcbbzy8EZXtz/jkRqHX8bFEc6FC1HjX4TUWYw==",
-      "dev": true,
+      "version": "0.9.6",
+      "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.9.6.tgz",
+      "integrity": "sha512-Su4xcxR0CPGwlDHNmVP09fqET9YxbyDXHaSob6JlBH7L6reTYaeim6zbk9o08UarO0L5GTRo3uzl0D+9lSxmvw==",
+      "license": "MIT",
       "engines": {
-        "node": ">=10.0.0"
+        "node": ">=14.6"
       }
     },
     "node_modules/abbrev": {
@@ -1150,14 +1187,6 @@
         }
       ]
     },
-    "node_modules/bindings": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
-      "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
-      "dependencies": {
-        "file-uri-to-path": "1.0.0"
-      }
-    },
     "node_modules/bl": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
@@ -1193,12 +1222,13 @@
       }
     },
     "node_modules/braces": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
-      "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
+      "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "fill-range": "^7.0.1"
+        "fill-range": "^7.1.1"
       },
       "engines": {
         "node": ">=8"
@@ -1576,11 +1606,20 @@
         "url": "https://opencollective.com/core-js"
       }
     },
-    "node_modules/cross-spawn": {
-      "version": "7.0.3",
-      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
-      "integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
+    "node_modules/cross-dirname": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/cross-dirname/-/cross-dirname-0.1.0.tgz",
+      "integrity": "sha512-+R08/oI0nl3vfPcqftZRpytksBXDzOUveBq/NBVx0sUp1axwzPQrKinNx5yd5sxPu8j1wIy8AfnVQ+5eFdha6Q==",
       "dev": true,
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "dev": true,
+      "license": "MIT",
       "dependencies": {
         "path-key": "^3.1.0",
         "shebang-command": "^2.0.0",
@@ -2241,21 +2280,25 @@
       }
     },
     "node_modules/electron-winstaller": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/electron-winstaller/-/electron-winstaller-5.1.2.tgz",
-      "integrity": "sha512-SJ+iTiXcKodXP4hHtvRtLOd0vtV5Z0mWjvf3JULQiGuZOoldDm5RLyl3I45Tyg6lC9S+DPsCx6gd4JILt08VXA==",
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/electron-winstaller/-/electron-winstaller-5.4.0.tgz",
+      "integrity": "sha512-bO3y10YikuUwUuDUQRM4KfwNkKhnpVO7IPdbsrejwN9/AABJzzTQ4GeHwyzNSrVO+tEH3/Np255a3sVZpZDjvg==",
       "dev": true,
       "hasInstallScript": true,
+      "license": "MIT",
       "optional": true,
       "dependencies": {
         "@electron/asar": "^3.2.1",
         "debug": "^4.1.1",
         "fs-extra": "^7.0.1",
-        "lodash.template": "^4.2.2",
+        "lodash": "^4.17.21",
         "temp": "^0.9.0"
       },
       "engines": {
         "node": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "@electron/windows-sign": "^1.1.2"
       }
     },
     "node_modules/electron-winstaller/node_modules/fs-extra": {
@@ -2416,9 +2459,10 @@
       }
     },
     "node_modules/execa/node_modules/cross-spawn": {
-      "version": "6.0.5",
-      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
-      "integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
+      "version": "6.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.6.tgz",
+      "integrity": "sha512-VqCUuhcd1iB+dsv8gxPttb5iZh/D0iubSP21g36KXdEuf6I5JiioesUVjpCdHV9MZRUfVFlvwtIUyPfxo5trtw==",
+      "license": "MIT",
       "dependencies": {
         "nice-try": "^1.0.4",
         "path-key": "^2.0.1",
@@ -2569,27 +2613,6 @@
         "node": ">=8.6.0"
       }
     },
-    "node_modules/fast-xml-parser": {
-      "version": "4.3.5",
-      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.3.5.tgz",
-      "integrity": "sha512-sWvP1Pl8H03B8oFJpFR3HE31HUfwtX7Rlf9BNsvdpujD4n7WMhfmu8h9wOV2u+c1k0ZilTADhPqypzx2J690ZQ==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/NaturalIntelligence"
-        },
-        {
-          "type": "paypal",
-          "url": "https://paypal.me/naturalintelligence"
-        }
-      ],
-      "dependencies": {
-        "strnum": "^1.0.5"
-      },
-      "bin": {
-        "fxparser": "src/cli/cli.js"
-      }
-    },
     "node_modules/fastq": {
       "version": "1.15.0",
       "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.15.0.tgz",
@@ -2607,11 +2630,6 @@
       "dependencies": {
         "pend": "~1.2.0"
       }
-    },
-    "node_modules/file-uri-to-path": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
-      "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw=="
     },
     "node_modules/filename-reserved-regex": {
       "version": "2.0.0",
@@ -2640,10 +2658,11 @@
       }
     },
     "node_modules/fill-range": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
-      "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
+      "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "to-regex-range": "^5.0.1"
       },
@@ -3109,15 +3128,6 @@
         "node": ">= 0.4"
       }
     },
-    "node_modules/hoek": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/hoek/-/hoek-4.2.1.tgz",
-      "integrity": "sha512-QLg82fGkfnJ/4iy1xZ81/9SIJiq1NGFUMGs6ParyjBZr6jW2Ufj/snDqTHixNlHdPNwN2RLVD0Pi3igeK9+JfA==",
-      "deprecated": "This version has been deprecated in accordance with the hapi support policy (hapi.im/support). Please upgrade to the latest version to get the best features, bug fixes, and security patches. If you are unable to upgrade at this time, paid support is available for older versions (hapi.im/commercial).",
-      "engines": {
-        "node": ">=4.0.0"
-      }
-    },
     "node_modules/homedir-polyfill": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/homedir-polyfill/-/homedir-polyfill-1.0.3.tgz",
@@ -3273,11 +3283,19 @@
         "node": ">=10.13.0"
       }
     },
-    "node_modules/ip": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/ip/-/ip-2.0.0.tgz",
-      "integrity": "sha512-WKa+XuLG1A1R0UWhl2+1XQSi+fZWMsYKffMZTTYsiZaUD8k2yDAj5atimTUD2TZkyCkNEeYE5NhFZmupOGtjYQ==",
-      "dev": true
+    "node_modules/ip-address": {
+      "version": "9.0.5",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-9.0.5.tgz",
+      "integrity": "sha512-zHtQzGojZXTwZTHQqra+ETKd4Sn3vgi7uBmlPoXVWZqYvuKmtI0l/VZTjqGmJY9x88GGOaZ9+G9ES8hC4T4X8g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "jsbn": "1.1.0",
+        "sprintf-js": "^1.1.3"
+      },
+      "engines": {
+        "node": ">= 12"
+      }
     },
     "node_modules/is-arrayish": {
       "version": "0.2.1",
@@ -3361,6 +3379,7 @@
       "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
       "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=0.12.0"
       }
@@ -3434,17 +3453,6 @@
         "url": "https://github.com/sponsors/gjtorikian/"
       }
     },
-    "node_modules/isemail": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/isemail/-/isemail-3.2.0.tgz",
-      "integrity": "sha512-zKqkK+O+dGqevc93KNsbZ/TqTUFd46MwWjYOoMrjIMZ51eU7DtQG3Wmd9SQQT7i7RVnuTPEiYEWHU3MSbxC1Tg==",
-      "dependencies": {
-        "punycode": "2.x.x"
-      },
-      "engines": {
-        "node": ">=4.0.0"
-      }
-    },
     "node_modules/isexe": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
@@ -3468,28 +3476,12 @@
         "@pkgjs/parseargs": "^0.11.0"
       }
     },
-    "node_modules/joi": {
-      "version": "13.7.0",
-      "resolved": "https://registry.npmjs.org/joi/-/joi-13.7.0.tgz",
-      "integrity": "sha512-xuY5VkHfeOYK3Hdi91ulocfuFopwgbSORmIwzcwHKESQhC7w1kD5jaVSPnqDxS2I8t3RZ9omCKAxNwXN5zG1/Q==",
-      "deprecated": "This version has been deprecated in accordance with the hapi support policy (hapi.im/support). Please upgrade to the latest version to get the best features, bug fixes, and security patches. If you are unable to upgrade at this time, paid support is available for older versions (hapi.im/commercial).",
-      "dependencies": {
-        "hoek": "5.x.x",
-        "isemail": "3.x.x",
-        "topo": "3.x.x"
-      },
-      "engines": {
-        "node": ">=8.9.0"
-      }
-    },
-    "node_modules/joi/node_modules/hoek": {
-      "version": "5.0.4",
-      "resolved": "https://registry.npmjs.org/hoek/-/hoek-5.0.4.tgz",
-      "integrity": "sha512-Alr4ZQgoMlnere5FZJsIyfIjORBqZll5POhDsF4q64dPuJR6rNxXdDxtHSQq8OXRurhmx+PWYEE8bXRROY8h0w==",
-      "deprecated": "This version has been deprecated in accordance with the hapi support policy (hapi.im/support). Please upgrade to the latest version to get the best features, bug fixes, and security patches. If you are unable to upgrade at this time, paid support is available for older versions (hapi.im/commercial).",
-      "engines": {
-        "node": ">=8.9.0"
-      }
+    "node_modules/jsbn": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-1.1.0.tgz",
+      "integrity": "sha512-4bYVV3aAMtDTTu4+xsDYa6sy9GyJ69/amsu9sYF2zqjiEoZA5xJi3BrfX3uY+/IekIu7MwdObdbDWpoZdBv3/A==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/json-buffer": {
       "version": "3.0.1",
@@ -3615,39 +3607,11 @@
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
       "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
     },
-    "node_modules/lodash._reinterpolate": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/lodash._reinterpolate/-/lodash._reinterpolate-3.0.0.tgz",
-      "integrity": "sha512-xYHt68QRoYGjeeM/XOE1uJtvXQAgvszfBhjV4yvsQH0u2i9I6cI6c6/eG4Hh3UAOVn0y/xAXwmTzEay49Q//HA==",
-      "dev": true,
-      "optional": true
-    },
     "node_modules/lodash.get": {
       "version": "4.4.2",
       "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
       "integrity": "sha512-z+Uw/vLuy6gQe8cfaFWD7p0wVv8fJl3mbzXh33RS+0oW2wvUqiRXiQ69gLWSLpgB5/6sU+r6BlQR0MBILadqTQ==",
       "dev": true
-    },
-    "node_modules/lodash.template": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/lodash.template/-/lodash.template-4.5.0.tgz",
-      "integrity": "sha512-84vYFxIkmidUiFxidA/KjjH9pAycqW+h980j7Fuz5qxRtO9pgB7MDFTdys1N7A5mcucRiDyEq4fusljItR1T/A==",
-      "dev": true,
-      "optional": true,
-      "dependencies": {
-        "lodash._reinterpolate": "^3.0.0",
-        "lodash.templatesettings": "^4.0.0"
-      }
-    },
-    "node_modules/lodash.templatesettings": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/lodash.templatesettings/-/lodash.templatesettings-4.2.0.tgz",
-      "integrity": "sha512-stgLz+i3Aa9mZgnjr/O+v9ruKZsPsndy7qPZOchbqk2cnTU1ZaldKK+v7m54WoKIyxiuMZTKT2H81F8BeAc3ZQ==",
-      "dev": true,
-      "optional": true,
-      "dependencies": {
-        "lodash._reinterpolate": "^3.0.0"
-      }
     },
     "node_modules/log-symbols": {
       "version": "4.1.0",
@@ -3813,12 +3777,13 @@
       }
     },
     "node_modules/micromatch": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.5.tgz",
-      "integrity": "sha512-DMy+ERcEW2q8Z2Po+WNXuw3c5YaUSFjAO5GsJqfEl7UjvtIuFKO6ZrKvcItdy98dwFI2N1tg3zNIdKaQT+aNdA==",
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
+      "integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "braces": "^3.0.2",
+        "braces": "^3.0.3",
         "picomatch": "^2.3.1"
       },
       "engines": {
@@ -4061,11 +4026,6 @@
       "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
       "dev": true
     },
-    "node_modules/nan": {
-      "version": "2.18.0",
-      "resolved": "https://registry.npmjs.org/nan/-/nan-2.18.0.tgz",
-      "integrity": "sha512-W7tfG7vMOGtD30sHoZSSc/JVYiyDPEyQVso/Zz+/uQd0B0L46gtC+pHha5FFMRpil6fm/AoEcRWyOVi4+E/f8w=="
-    },
     "node_modules/negotiator": {
       "version": "0.6.3",
       "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.3.tgz",
@@ -4099,16 +4059,6 @@
       "dev": true,
       "dependencies": {
         "semver": "^7.3.5"
-      }
-    },
-    "node_modules/node-expat": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/node-expat/-/node-expat-2.4.0.tgz",
-      "integrity": "sha512-X8Y/Zk/izfNgfayeOeUGqze7KlaOwVJ9SDTjHUMKd0hu0aFTRpLlLCBwmx79cTPiQWD24I1YOafF+U+rTvEMfQ==",
-      "hasInstallScript": true,
-      "dependencies": {
-        "bindings": "^1.5.0",
-        "nan": "^2.13.2"
       }
     },
     "node_modules/node-fetch": {
@@ -4673,6 +4623,44 @@
       },
       "engines": {
         "node": ">=10.4.0"
+      }
+    },
+    "node_modules/plist/node_modules/@xmldom/xmldom": {
+      "version": "0.8.10",
+      "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.8.10.tgz",
+      "integrity": "sha512-2WALfTl4xo2SkGCYRt6rDTFfk9R1czmBvUQy12gK2KuRKIpWEhcbbzy8EZXtz/jkRqHX8bFEc6FC1HjX4TUWYw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
+    "node_modules/postject": {
+      "version": "1.0.0-alpha.6",
+      "resolved": "https://registry.npmjs.org/postject/-/postject-1.0.0-alpha.6.tgz",
+      "integrity": "sha512-b9Eb8h2eVqNE8edvKdwqkrY6O7kAwmI8kcnBv1NScolYJbo59XUF0noFq+lxbC1yN20bmC0WBEbDC5H/7ASb0A==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "commander": "^9.4.0"
+      },
+      "bin": {
+        "postject": "dist/cli.js"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/postject/node_modules/commander": {
+      "version": "9.5.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-9.5.0.tgz",
+      "integrity": "sha512-KRs7WVDKg86PWiuAqhDrAQnTXZKraVcCc6vFdL14qrZ/DcWwuRo7VoiYXalXO7S5GKpqYiVEwCbgFDfxNHKJBQ==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": "^12.20.0 || >=14"
       }
     },
     "node_modules/progress": {
@@ -5262,16 +5250,17 @@
       }
     },
     "node_modules/socks": {
-      "version": "2.7.1",
-      "resolved": "https://registry.npmjs.org/socks/-/socks-2.7.1.tgz",
-      "integrity": "sha512-7maUZy1N7uo6+WVEX6psASxtNlKaNVMlGQKkG/63nEDdLOWNbiUMoLK7X4uYoLhQstau72mLgfEWcXcwsaHbYQ==",
+      "version": "2.8.3",
+      "resolved": "https://registry.npmjs.org/socks/-/socks-2.8.3.tgz",
+      "integrity": "sha512-l5x7VUUWbjVFbafGLxPWkYsHIhEvmF85tbIeFZWc8ZPtoMyybuEhL7Jye/ooC4/d48FgOjSJXgsF/AJPYCW8Zw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "ip": "^2.0.0",
+        "ip-address": "^9.0.5",
         "smart-buffer": "^4.2.0"
       },
       "engines": {
-        "node": ">= 10.13.0",
+        "node": ">= 10.0.0",
         "npm": ">= 3.0.0"
       }
     },
@@ -5366,8 +5355,7 @@
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.3.tgz",
       "integrity": "sha512-Oo+0REFV59/rz3gfJNKQiBlwfHaSESl1pcGyABQsnnIfWOFt6JNj5gCog2U6MLZ//IGYD+nA8nI+mTShREReaA==",
-      "dev": true,
-      "optional": true
+      "dev": true
     },
     "node_modules/ssri": {
       "version": "10.0.5",
@@ -5489,11 +5477,6 @@
         "node": ">=0.8.0"
       }
     },
-    "node_modules/strnum": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/strnum/-/strnum-1.0.5.tgz",
-      "integrity": "sha512-J8bbNyKKXl5qYcR36TIO8W3mVGVHrmmxsd5PAItGkmyzwJvybiw2IVq5nqd0i4LSNSkB/sx9VHllbfFdr9k1JA=="
-    },
     "node_modules/sudo-prompt": {
       "version": "9.2.1",
       "resolved": "https://registry.npmjs.org/sudo-prompt/-/sudo-prompt-9.2.1.tgz",
@@ -5555,10 +5538,11 @@
       }
     },
     "node_modules/tar": {
-      "version": "6.2.0",
-      "resolved": "https://registry.npmjs.org/tar/-/tar-6.2.0.tgz",
-      "integrity": "sha512-/Wo7DcT0u5HUV486xg675HtjNd3BXZ6xDbzsCUZPt5iw8bTQ63bP0Raut3mvro9u+CUyq7YQd8Cx55fsZXxqLQ==",
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-6.2.1.tgz",
+      "integrity": "sha512-DZ4yORTwrbTj/7MZYq2w+/ZFdI6OZ/f9SFHR+71gIVUZhOQPHzVCLpvRnPgyaMpfWxxk/4ONva3GQSyNIKRv6A==",
       "dev": true,
+      "license": "ISC",
       "dependencies": {
         "chownr": "^2.0.0",
         "fs-minipass": "^2.0.0",
@@ -5676,27 +5660,13 @@
       "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
       "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "is-number": "^7.0.0"
       },
       "engines": {
         "node": ">=8.0"
       }
-    },
-    "node_modules/topo": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/topo/-/topo-3.0.3.tgz",
-      "integrity": "sha512-IgpPtvD4kjrJ7CRA3ov2FhWQADwv+Tdqbsf1ZnPUSAtCJ9e1Z44MmoSGDXGk4IppoZA7jd/QRkNddlLJWlUZsQ==",
-      "deprecated": "This module has moved and is now available at @hapi/topo. Please update your dependencies as this version is no longer maintained an may contain bugs and security issues.",
-      "dependencies": {
-        "hoek": "6.x.x"
-      }
-    },
-    "node_modules/topo/node_modules/hoek": {
-      "version": "6.1.3",
-      "resolved": "https://registry.npmjs.org/hoek/-/hoek-6.1.3.tgz",
-      "integrity": "sha512-YXXAAhmF9zpQbC7LEcREFtXfGq5K1fmd+4PHkBq8NUqmzW3G+Dq10bI/i0KucLRwss3YYFQ0fSfoxBZYiGUqtQ==",
-      "deprecated": "This module has moved and is now available at @hapi/hoek. Please update your dependencies as this version is no longer maintained an may contain bugs and security issues."
     },
     "node_modules/tr46": {
       "version": "0.0.3",
@@ -5936,19 +5906,6 @@
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="
     },
-    "node_modules/xml2json": {
-      "version": "0.12.0",
-      "resolved": "https://registry.npmjs.org/xml2json/-/xml2json-0.12.0.tgz",
-      "integrity": "sha512-EPJHRWJnJUYbJlzR4pBhZODwWdi2IaYGtDdteJi0JpZ4OD31IplWALuit8r73dJuM4iHZdDVKY1tLqY2UICejg==",
-      "dependencies": {
-        "hoek": "^4.2.1",
-        "joi": "^13.1.2",
-        "node-expat": "^2.3.18"
-      },
-      "bin": {
-        "xml2json": "bin/xml2json"
-      }
-    },
     "node_modules/xmlbuilder": {
       "version": "15.1.1",
       "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-15.1.1.tgz",
@@ -5956,6 +5913,15 @@
       "dev": true,
       "engines": {
         "node": ">=8.0"
+      }
+    },
+    "node_modules/xpath": {
+      "version": "0.0.34",
+      "resolved": "https://registry.npmjs.org/xpath/-/xpath-0.0.34.tgz",
+      "integrity": "sha512-FxF6+rkr1rNSQrhUNYrAFJpRXNzlDoMxeXN5qI84939ylEv3qqPFKa85Oxr6tDaJKqwW6KKyo2v26TSv3k6LeA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6.0"
       }
     },
     "node_modules/xregexp": {
@@ -6025,10 +5991,11 @@
       }
     },
     "node_modules/yarn-or-npm/node_modules/cross-spawn": {
-      "version": "6.0.5",
-      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
-      "integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
+      "version": "6.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.6.tgz",
+      "integrity": "sha512-VqCUuhcd1iB+dsv8gxPttb5iZh/D0iubSP21g36KXdEuf6I5JiioesUVjpCdHV9MZRUfVFlvwtIUyPfxo5trtw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "nice-try": "^1.0.4",
         "path-key": "^2.0.1",

--- a/signaturenDruck/package.json
+++ b/signaturenDruck/package.json
@@ -1,13 +1,14 @@
 {
   "name": "SignaturenDruck",
-  "version": "1.3.20",
+  "version": "1.3.21",
   "description": "SignaturenDruck der ThULB",
   "main": "main.js",
   "dependencies": {
     "electron-context-menu": "^3.1.1",
     "electron-squirrel-startup": "^1.0.0",
     "electron-store": "^8.0.1",
-    "fast-xml-parser": "^4.3.5",
+    "xpath": "^0.0.34",
+    "@xmldom/xmldom": "^0.9.6",
     "lodash": "^4.17.21",
     "moment": "^2.29.1",
     "pdf-to-printer": "^5.0.0",


### PR DESCRIPTION
Hallo Elias,
zweiter Anlauf: Zunächst vielen Dank für dieses nützliche Signaturen-Druckprogramm, das wir bereits einsetzen!

Ich habe es erweitert, so dass es auch für die SRU-Schnitstelle von FOLIO genutzt werden kann. Der Eingriff ist etwas größer, als zunächst beabsichtigt, da die Objekte des fast-xml-parser beim xml von FOLIO unhandlich und zu variantenreich werden. Deshalb habe ich für das Auslesen der xml-Daten den Parser mit xpath ersetzt - mit der geichen Funktion für den K10Plus.

Die Schnittstellenerweiterung ist nützlich für Bibliotheken, die nicht im K10Plus sind. Zur Konfiguration reicht es, die URL der SRU-Schnittstelle von FOLIO mit dem Schema "raw" zu konfigurieren. Das Datenschema (picaxml oder raw) wird dann im xml automatisch erkannt. Ein paar Felder werden sinngemäß, aber etwas anders belegt (item-hrid anstelle ppn oder epn, location anstelle der occurrence, der Ausleihindikator ist im Klartext).

Vielleicht wollt ihr die Erweiterung übernehmen? Das würde mich freuen.

Beste Grüße nach Jena
Marko

![signaturdruck](https://github.com/user-attachments/assets/dfe5619f-ff62-459e-ac2f-2b07a7a0448e)