### PR TITLE
FOLIO SRU Update

### DIFF
--- a/signaturenDruck/js/classes/ShelfmarksFromSRUData.js
+++ b/signaturenDruck/js/classes/ShelfmarksFromSRUData.js
@@ -77,7 +77,7 @@ class ShelfmarksFromSRUData {
  
        case 'raw':  // FOLIO "Quesnelia"
           if (dataMode === 'PPN') {
-            sig.ppn = xpath.select("translate(string(//bareHoldingsItems[barcode='"+key+"']/hrid),'-','_')", sru)
+            sig.ppn = xpath.select("translate(string(//bareHoldingsItems[barcode='"+key+"']/../permanentLocation/name),'-','_')", sru)
             sig.date = xpath.select("string(//bareHoldingsItems[barcode='"+key+"']/../notes[holdingsNoteType/name='Letzte Änderung CBS']/note)", sru)
             sig.txtOneLine = [
                  xpath.select("string(//bareHoldingsItems[barcode='"+key+"']/effectiveCallNumberComponents/prefix)", sru),
@@ -86,7 +86,7 @@ class ShelfmarksFromSRUData {
                  xpath.select("string(//bareHoldingsItems[barcode='"+key+"']/chronology)", sru)
                  ].filter(Boolean).join(" ")
             sig.location = xpath.select("string(//bareHoldingsItems[barcode='"+key+"']/../permanentLocation/name)", sru)
-            sig.exNr = sig.location
+            sig.exNr = xpath.select("string(//bareHoldingsItems[barcode='"+key+"']/hrid)", sru)
             sig.loanIndication = xpath.select("string(//bareHoldingsItems[barcode='"+key+"']/status/name)", sru)
           } else {
             sig.error = 'SRU: EPN-Suche für FOLIO raw nicht implementiert'

--- a/signaturenDruck/js/classes/ShelfmarksFromSRUData.js
+++ b/signaturenDruck/js/classes/ShelfmarksFromSRUData.js
@@ -77,20 +77,21 @@ class ShelfmarksFromSRUData {
  
        case 'raw':  // FOLIO "Quesnelia"
           if (dataMode === 'PPN') {
-            sig.ppn = xpath.select("translate(string(//bareHoldingsItems[barcode='"+key+"']/../permanentLocation/name),'-','_')", sru)
-            sig.date = xpath.select("string(//bareHoldingsItems[barcode='"+key+"']/../notes[holdingsNoteType/name='Letzte Änderung CBS']/note)", sru)
-            sig.txtOneLine = [
-                 xpath.select("string(//bareHoldingsItems[barcode='"+key+"']/effectiveCallNumberComponents/prefix)", sru),
-                 xpath.select("string(//bareHoldingsItems[barcode='"+key+"']/effectiveCallNumberComponents/callNumber)", sru),
-                 xpath.select("string(//bareHoldingsItems[barcode='"+key+"']/effectiveCallNumberComponents/suffix)", sru),
-                 xpath.select("string(//bareHoldingsItems[barcode='"+key+"']/chronology)", sru)
-                 ].filter(Boolean).join(" ")
-            sig.location = xpath.select("string(//bareHoldingsItems[barcode='"+key+"']/../permanentLocation/name)", sru)
-            sig.exNr = xpath.select("string(//bareHoldingsItems[barcode='"+key+"']/hrid)", sru)
-            sig.loanIndication = xpath.select("string(//bareHoldingsItems[barcode='"+key+"']/status/name)", sru)
+            var hrid = xpath.select("string(//bareHoldingsItems[barcode='"+key+"']/hrid)", sru)
           } else {
-            sig.error = 'SRU: EPN-Suche für FOLIO raw nicht implementiert'
+            var hrid = key
           }
+          sig.ppn = xpath.select("translate(string(//bareHoldingsItems[hrid='"+hrid+"']/../permanentLocation/name),'-','_')", sru)
+          sig.date = xpath.select("string(//bareHoldingsItems[hrid='"+hrid+"']/../notes[holdingsNoteType/name='Letzte Änderung CBS']/note)", sru)
+          sig.txtOneLine = [
+             xpath.select("string(//bareHoldingsItems[hrid='"+hrid+"']/effectiveCallNumberComponents/prefix)", sru),
+             xpath.select("string(//bareHoldingsItems[hrid='"+hrid+"']/effectiveCallNumberComponents/callNumber)", sru),
+             xpath.select("string(//bareHoldingsItems[hrid='"+hrid+"']/effectiveCallNumberComponents/suffix)", sru),
+             xpath.select("string(//bareHoldingsItems[hrid='"+hrid+"']/chronology)", sru)
+             ].filter(Boolean).join(" ")
+          sig.location = xpath.select("string(//bareHoldingsItems[hrid='"+hrid+"']/../permanentLocation/name)", sru)
+          sig.exNr = hrid
+          sig.loanIndication = xpath.select("string(//bareHoldingsItems[hrid='"+hrid+"']/status/name)", sru)
           break
 
        default:

--- a/signaturenDruck/js/classes/ShelfmarksFromSRUData.js
+++ b/signaturenDruck/js/classes/ShelfmarksFromSRUData.js
@@ -88,11 +88,13 @@ class ShelfmarksFromSRUData {
           }
           sig.ppn = xpath.select("translate(string(//bareHoldingsItems[hrid='"+hrid+"']/../permanentLocation/name),'-','_')", sru)
           sig.date = xpath.select("string(//bareHoldingsItems[hrid='"+hrid+"']/../notes[holdingsNoteType/name='Letzte Änderung CBS']/note)", sru)
+          var copyno = xpath.select("string(//bareHoldingsItems[hrid='"+hrid+"']/copyNumber)", sru)
           sig.txtOneLine = [
              xpath.select("string(//bareHoldingsItems[hrid='"+hrid+"']/effectiveCallNumberComponents/prefix)", sru),
              xpath.select("string(//bareHoldingsItems[hrid='"+hrid+"']/effectiveCallNumberComponents/callNumber)", sru),
              xpath.select("string(//bareHoldingsItems[hrid='"+hrid+"']/effectiveCallNumberComponents/suffix)", sru),
-             xpath.select("string(//bareHoldingsItems[hrid='"+hrid+"']/chronology)", sru)
+             xpath.select("string(//bareHoldingsItems[hrid='"+hrid+"']/chronology)", sru),
+             copyno ? '('+copyno+'.Ex.)' : ''
              ].filter(Boolean).join(" ")
           sig.location = xpath.select("string(//bareHoldingsItems[hrid='"+hrid+"']/../permanentLocation/name)", sru)
           sig.exNr = hrid

--- a/signaturenDruck/js/classes/ShelfmarksFromSRUData.js
+++ b/signaturenDruck/js/classes/ShelfmarksFromSRUData.js
@@ -82,7 +82,8 @@ class ShelfmarksFromSRUData {
             sig.txtOneLine = [
                  xpath.select("string(//bareHoldingsItems[barcode='"+key+"']/effectiveCallNumberComponents/prefix)", sru),
                  xpath.select("string(//bareHoldingsItems[barcode='"+key+"']/effectiveCallNumberComponents/callNumber)", sru),
-                 xpath.select("string(//bareHoldingsItems[barcode='"+key+"']/effectiveCallNumberComponents/suffix)", sru)
+                 xpath.select("string(//bareHoldingsItems[barcode='"+key+"']/effectiveCallNumberComponents/suffix)", sru),
+                 xpath.select("string(//bareHoldingsItems[barcode='"+key+"']/chronology)", sru)
                  ].filter(Boolean).join(" ")
             sig.location = xpath.select("string(//bareHoldingsItems[barcode='"+key+"']/../permanentLocation/name)", sru)
             sig.exNr = sig.location

--- a/signaturenDruck/js/classes/ShelfmarksFromSRUData.js
+++ b/signaturenDruck/js/classes/ShelfmarksFromSRUData.js
@@ -83,7 +83,7 @@ class ShelfmarksFromSRUData {
                  xpath.select("string(//bareHoldingsItems[barcode='"+key+"']/effectiveCallNumberComponents/prefix)", sru),
                  xpath.select("string(//bareHoldingsItems[barcode='"+key+"']/effectiveCallNumberComponents/callNumber)", sru),
                  xpath.select("string(//bareHoldingsItems[barcode='"+key+"']/effectiveCallNumberComponents/suffix)", sru)
-                 ].join(" ")
+                 ].filter(Boolean).join(" ")
             sig.location = xpath.select("string(//bareHoldingsItems[barcode='"+key+"']/../permanentLocation/name)", sru)
             sig.exNr = sig.location
             sig.loanIndication = xpath.select("string(//bareHoldingsItems[barcode='"+key+"']/status/name)", sru)

--- a/signaturenDruck/js/classes/ShelfmarksFromSRUData.js
+++ b/signaturenDruck/js/classes/ShelfmarksFromSRUData.js
@@ -79,7 +79,12 @@ class ShelfmarksFromSRUData {
           if (dataMode === 'PPN') {
             var hrid = xpath.select("string(//bareHoldingsItems[barcode='"+key+"']/hrid)", sru)
           } else {
-            var hrid = key
+            if (xpath.select("boolean(//bareHoldingsItems[hrid='"+key+"']/hrid)", sru)) {
+               var hrid = key // key is item hrid
+            } else {
+               var hrid = xpath.select("string(//bareHoldingsItems[substring-before(hrid,'-')='"+key+"']/hrid)", sru)
+               // key is holdings hrid/EPN - workaround working at least for GBV and Hebis (holdings hrid missing in raw format) 
+               }
           }
           sig.ppn = xpath.select("translate(string(//bareHoldingsItems[hrid='"+hrid+"']/../permanentLocation/name),'-','_')", sru)
           sig.date = xpath.select("string(//bareHoldingsItems[hrid='"+hrid+"']/../notes[holdingsNoteType/name='Letzte Änderung CBS']/note)", sru)


### PR DESCRIPTION
Hallo Elias,

ich habe an ein paar Stellen geschraubt - betrifft nur den FOLIO-Teil:

- In der Übersicht habe ich jetzt für die _occurence_-Spalte statt der _location_ die _hrid_ genommen - gruppiert wird jetzt mit der _location_. Das ist übersichtlicher.
- Die Signatur wird jetzt durch die _copyNumber_ mit (_n_.Ex) bei Mehrfachexemplaren und _chronology_ für Zeitschriften ergänzt, so dass Bandsignaturen gedruckt werden können.
- Die EPN-Funktion ist ergänzt, so dass die Daten mit der _item hrid_ oder der _holdings hrid_ (=EPN) geholt werden können. Für letzters ist ein Workaround nötig, der aber zumindest beim GBV und bei Hebis funktioniert.

Welcher Identifier genutzt wird, hängt von der SRU-Konfiguration ab. Eine Konfiguration mit _holdings hrid_ (=EPN) sieht so aus:
```
    SRUAddress: 'https://example.url.to.folio/sru',
    QueryPart1: '?version=1.1&operation=searchRetrieve&query=item.barcode==',
    QueryPart1EPN: '?version=1.1&operation=searchRetrieve&query=holdings.hrid==',
    QueryPart2: '&maximumRecords=1&recordSchema=raw'
```
und mit _item hrid_ stattdessen` QueryPart1EPN: '?version=1.1&operation=searchRetrieve&query=item.hrid==',`.

Viele Grüße

Marko